### PR TITLE
Fix compat issue with 64-bit

### DIFF
--- a/r.sh
+++ b/r.sh
@@ -57,6 +57,7 @@ function put_getvar_source {
 cat > .getvar.c <<EOF
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 void printvar(char * p, char * varname) {
     unsigned char *q;
     q = (unsigned char *)&p;


### PR DESCRIPTION
Recent gcc with 64-bit treats the return value of `getenv` as a 32-bit pointer when `stdlib.h` is not included.

```
echo 'void main() { printf("%p\n", getenv("PATH")); }' > bad.c
echo '#include <stdlib.h>' > good.c
cat bad.c >> good.c
gcc -ogood good.c
gcc -obad bad.c
```

```
$ ./bad
0x265a1895
$ ./good
0x7fff15d69893
```
